### PR TITLE
fix(iOS): Clean exit the process on exception

### DIFF
--- a/airtest/core/ios/rotation.py
+++ b/airtest/core/ios/rotation.py
@@ -96,7 +96,7 @@ class RotationWatcher(object):
 
         self.roundProcess = threading.Thread(
             target=_run, name="rotationwatcher")
-        # self._t.daemon = True
+        self.roundProcess.daemon = True
         self.roundProcess.start()
 
     def reg_callback(self, ow_callback):


### PR DESCRIPTION
The comment # self._t.daemon = True references the old variable name _t — someone refactored the variable to roundProcess but didn't update or uncomment the daemon line.

  With daemon = True, when the main thread exits (via sys.exit() / SystemExit), Python will forcibly kill the rotationwatcher thread instead of waiting for it to finish.